### PR TITLE
pglookout: Fix broken main() entry point for current_master

### DIFF
--- a/pglookout/current_master.py
+++ b/pglookout/current_master.py
@@ -10,7 +10,9 @@ import os
 import sys
 import time
 
-def main(args):
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     if len(args) != 1:
         print("Usage, pglookout_current_master <path_to_pglookout.json>")
         return -1


### PR DESCRIPTION
Following the lines of 6e4ce4d, fix also current_master entry point.