### PR TITLE
pglookout: prefer simplejson over json, if simplejson is available

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,4 +8,5 @@ Standards-Version: 3.9.1
 Package: pglookout
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}, python-psycopg2 (>= 2.4.0-1), python-requests (>= 1.2.0-1)
+Suggests: python-simplejson (>= 2.1.1-1)
 Description: pglookout provides a monitoring/failover service for PostgreSQL streaming replication.

--- a/pglookout/current_master.py
+++ b/pglookout/current_master.py
@@ -6,10 +6,14 @@ See LICENSE for details
 """
 
 from __future__ import print_function
-import json
 import os
 import sys
 import time
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 def main(args=None):
     if args is None:

--- a/pglookout/pglookout.py
+++ b/pglookout/pglookout.py
@@ -9,7 +9,6 @@ from __future__ import print_function
 import copy
 import datetime
 import errno
-import json
 import logging
 import logging.handlers
 import os
@@ -33,6 +32,14 @@ try:
 except ImportError: # Support Py3k
     from socketserver import ThreadingMixIn # pylint: disable=F0401
     from http.server import HTTPServer, SimpleHTTPRequestHandler # pylint: disable=F0401
+
+# Prefer simplejson over json as on Python2.6 json does not play together
+# nicely with other libraries as it loads strings in unicode and for example
+# SysLogHandler does not like getting syslog facility as unicode string.
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 try:
     from systemd import daemon  # pylint: disable=F0401


### PR DESCRIPTION
This happens at least with python 2.6.6:

After the change 8816adbbb, pglookout stopped working with Python 2.6 as
json behaves slightly differently when compared to simplejson. Namely,
json library converts all strings to unicode whereas simplejson left strings
as str if the whole input is ASCII only. I believe this is an issue many
have faced with simplejson: https://code.google.com/p/simplejson/issues/detail?id=40

To make it work, prefer simplejson over json when it is available.

This should prevent following tracebacks:

    2015-01-26 18:28:47,551pglookoutDEBUGLoading JSON config from: '/etc/pglookout/pglookout.json', signal: None, frame: None
    Traceback (most recent call last):
      File "/usr/bin/pglookout", line 9, in <module>
        load_entry_point('pglookout==1.0.0', 'console_scripts', 'pglookout')()
      File "/usr/lib/python2.6/dist-packages/pglookout/pglookout.py", line 651, in main
        pglookout = PgLookout(args[0])
      File "/usr/lib/python2.6/dist-packages/pglookout/pglookout.py", line 114, in __init__
        self.observer_state, self.create_alert_file)
      File "/usr/lib/python2.6/dist-packages/pglookout/pglookout.py", line 524, in __init__
        self.log.debug("Initialized ClusterMonitor with: %r", cluster_state)
      File "/usr/lib/python2.6/logging/__init__.py", line 1044, in debug
        self._log(DEBUG, msg, args, **kwargs)
      File "/usr/lib/python2.6/logging/__init__.py", line 1173, in _log
        self.handle(record)
      File "/usr/lib/python2.6/logging/__init__.py", line 1183, in handle
        self.callHandlers(record)
      File "/usr/lib/python2.6/logging/__init__.py", line 1220, in callHandlers
        hdlr.handle(record)
      File "/usr/lib/python2.6/logging/__init__.py", line 679, in handle
        self.emit(record)
      File "/usr/lib/python2.6/logging/handlers.py", line 783, in emit
        self.mapPriority(record.levelname)),
      File "/usr/lib/python2.6/logging/handlers.py", line 749, in encodePriority
        return (facility << 3) | priority
    TypeError: unsupported operand type(s) for <<: 'unicode' and 'int'