### PR TITLE
rpm: Build just a single package using Python 3 if possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.4"
 
 install:
-  - "pip install pylint pytest mock psycopg2 requests"
+  - "pip install pylint==1.3.1 pytest mock psycopg2 requests"
 
 script:
   - "(python -V 2>&1 | grep -qF 'Python 2.6') || make pylint"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ unittest:
 	$(PYTHON) -m pytest -vv test/
 
 pylint:
-	$(PYTHON) -m pylint --rcfile .pylintrc $(PYLINT_DIRS)
+	$(PYTHON) -m pylint.lint --rcfile .pylintrc $(PYLINT_DIRS)
 
 coverage:
 	$(PYTHON) -m pytest $(PYTEST_ARG) --cov-report term-missing --cov pglookout test/

--- a/pglookout.spec
+++ b/pglookout.spec
@@ -1,61 +1,54 @@
+%if %{?python3_sitelib:1}0
+%global use_python3 1
+%else
+%global use_python3 0
+%endif
+
 Name:           pglookout
 Version:        %{major_version}
 Release:        %{minor_version}%{?dist}
 Url:            http://github.com/ohmu/pglookout
-Summary:        PostgreSQL replication monitoring and failover daemon (Python 2)
+Summary:        PostgreSQL replication monitoring and failover daemon
 License:        ASL 2.0
 Source0:        pglookout-rpm-src.tar.gz
-Requires:       python-psycopg2, python-requests, python-setuptools, systemd-python, systemd
 Requires(pre):  shadow-utils
-BuildRequires:  pytest, pylint, %{requires}
+%if %{use_python3}
+Obsoletes:      python3-pglookout
+Requires:       python3-psycopg2, python3-requests, python3-setuptools, systemd-python3, systemd
+BuildRequires:  python3-pytest, python3-pylint
+%else
+Requires:       python-psycopg2, python-requests, python-setuptools, systemd-python, systemd
+BuildRequires:  pytest, pylint
+%endif
+BuildRequires:  %{requires}
 BuildArch:      noarch
 
 %description
 pglookout is a PostgreSQL replication monitoring and failover daemon.
 
-This is the Python 2 package of pglookout.
-
-%if %{?python3_sitelib:1}0
-%package -n python3-pglookout
-Summary:        PostgreSQL replication monitoring and failover daemon (Python 3)
-Requires:       python3-psycopg2, python3-requests, python3-setuptools, systemd-python3, systemd
-Requires(pre):  shadow-utils
-BuildRequires:  python3-pytest, python3-pylint, %{requires}
-BuildArch:      noarch
-
-%description -n python3-pglookout
-pglookout is a PostgreSQL replication monitoring and failover daemon.
-
-This is the Python 3 package of pglookout.
-%endif
 
 %prep
 %setup -q -n pglookout
 
+
 %install
-%{__mkdir_p} %{buildroot}%{_localstatedir}/lib/pglookout %{buildroot}%{_datadir}/pglookout
-
-python2 setup.py install --prefix=%{_prefix} --root=%{buildroot}
-mv %{buildroot}%{_bindir}/pglookout_current_master %{buildroot}%{_bindir}/pglookout_current_master-py2
-mv %{buildroot}%{_bindir}/pglookout %{buildroot}%{_bindir}/pglookout-py2
-sed -e "s!/usr/bin/pglookout /var/!%{_bindir}/pglookout-py2 %{_localstatedir}/!g" pglookout.unit \
-    > %{buildroot}%{_datadir}/pglookout/pglookout-py2.service
-
-%if %{?python3_sitelib:1}0
+%if %{use_python3}
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
-mv %{buildroot}%{_bindir}/pglookout_current_master %{buildroot}%{_bindir}/pglookout_current_master-py3
-mv %{buildroot}%{_bindir}/pglookout %{buildroot}%{_bindir}/pglookout-py3
-sed -e "s!/usr/bin/pglookout /var/!%{_bindir}/pglookout-py3 %{_localstatedir}/!g" pglookout.unit \
-    > %{buildroot}%{_datadir}/pglookout/pglookout-py3.service
+%else
+python2 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 %endif
-
 sed -e "s@#!/bin/python@#!%{_bindir}/python@" -i %{buildroot}%{_bindir}/*
+%{__install} -Dm0644 pglookout.unit %{buildroot}%{_unitdir}/pglookout.service
+%{__mkdir_p} %{buildroot}%{_localstatedir}/lib/pglookout
+
 
 %check
-make test PYTHON=python2
-%if %{?python3_sitelib:1}0
+%if %{use_python3}
 make test PYTHON=python3
+%else
+make test PYTHON=python2
 %endif
+
 
 %pre
 getent group pglookout >/dev/null || groupadd -r pglookout
@@ -63,53 +56,24 @@ getent passwd pglookout >/dev/null || \
     useradd -r -g pglookout -d %{_localstatedir}/lib/pglookout -s /usr/bin/sh \
 	    -c "pglookout account" pglookout
 
-%post
-[ -L %{_bindir}/pglookout ] || ln -sf pglookout-py2 %{_bindir}/pglookout
-[ -L %{_bindir}/pglookout_current_master ] || ln -sf pglookout_current_master-py2 %{_bindir}/pglookout_current_master
-[ -L %{_unitdir}/pglookout.service ] || ln -sf %{_datadir}/pglookout/pglookout-py2.service %{_unitdir}/pglookout.service
-
-%if %{?python3_sitelib:1}0
-%pre -n python3-pglookout
-getent group pglookout >/dev/null || groupadd -r pglookout
-getent passwd pglookout >/dev/null || \
-    useradd -r -g pglookout -d %{_localstatedir}/lib/pglookout -s /usr/bin/sh \
-	    -c "pglookout account" pglookout
-
-%post -n python3-pglookout
-[ -L %{_bindir}/pglookout ] || ln -sf pglookout-py3 %{_bindir}/pglookout
-[ -L %{_bindir}/pglookout_current_master ] || ln -sf pglookout_current_master-py3 %{_bindir}/pglookout_current_master
-[ -L %{_unitdir}/pglookout.service ] || ln -sf %{_datadir}/pglookout/pglookout-py3.service %{_unitdir}/pglookout.service
-%endif
 
 %files
 %defattr(-,root,root,-)
 %doc LICENSE README.rst pglookout.json
-%{_bindir}/pglookout-py2
-%{_bindir}/pglookout_current_master-py2
+%{_bindir}/pglookout*
+%{_unitdir}/pglookout.service
+%if %{use_python3}
+%{python3_sitelib}/*
+%else
 %{python_sitelib}/*
-%{_datadir}/pglookout/pglookout-py2.service
-%dir %{_datadir}/pglookout
-%ghost %{_unitdir}/pglookout.service
-%ghost %{_bindir}/pglookout
-%ghost %{_bindir}/pglookout_current_master
+%endif
 %attr(0755, pglookout, pglookout) %{_localstatedir}/lib/pglookout
 
-%if %{?python3_sitelib:1}0
-%files -n python3-pglookout
-%defattr(-,root,root,-)
-%doc LICENSE README.rst pglookout.json
-%{_bindir}/pglookout-py3
-%{_bindir}/pglookout_current_master-py3
-%{python3_sitelib}/*
-%{_datadir}/pglookout/pglookout-py3.service
-%dir %{_datadir}/pglookout
-%attr(0755, pglookout, pglookout) %{_localstatedir}/lib/pglookout
-%ghost %{_unitdir}/pglookout.service
-%ghost %{_bindir}/pglookout
-%ghost %{_bindir}/pglookout_current_master
-%endif
 
 %changelog
+* Wed Mar 25 2015 Oskari Saarenmaa <os@ohmu.fi> - 1.1.0-9
+* Build just a single package using Python 3 if possible, Python 2 otherwise
+
 * Fri Feb 27 2015 Oskari Saarenmaa <os@ohmu.fi> - 1.1.0
 - Refactored
 - Python 3 support

--- a/pglookout/pglookout.py
+++ b/pglookout/pglookout.py
@@ -513,11 +513,8 @@ def wait_select(conn, timeout=10.0):
                 select.select([], [conn.fileno()], [], min(timeout, time_left))
             else:
                 raise psycopg2.OperationalError("bad state from poll: %s" % state)
-        except OSError as error:
-            if error.errno != errno.EINTR:
-                raise
         except select.error as error:
-            if error[0] != errno.EINTR:  # pylint: disable=W0713
+            if error.args[0] != errno.EINTR:
                 raise
     raise PglookoutTimeout("timed out in wait_select")
 


### PR DESCRIPTION
Also, run pylint from `pylint.lint` instead of `pylint` for compatibility
and drop an unnecessary pylint disable for W0713 which didn't work on CentOS
7's pylint.