### PR TITLE
failover: perform failover if master node disappears or never appears

### DIFF
--- a/pglookout/common.py
+++ b/pglookout/common.py
@@ -5,6 +5,8 @@ Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
 
+import datetime
+import re
 try:
     from urllib.parse import urlparse, parse_qs  # pylint: disable=no-name-in-module, import-error
 except ImportError:
@@ -89,3 +91,33 @@ def parse_connection_string_libpq(connection_string):
                 value, connection_string = rem, ""
         fields[key] = value
     return fields
+
+
+def convert_xlog_location_to_offset(xlog_location):
+    log_id, offset = xlog_location.split("/")
+    return int(log_id, 16) << 32 | int(offset, 16)
+
+
+ISO_EXT_RE = re.compile(r'(?P<year>\d{4})-(?P<month>\d\d)-(?P<day>\d\d)(T(?P<hour>\d\d):(?P<minute>\d\d)'
+                        r'(:(?P<second>\d\d)(.(?P<microsecond>\d{6}))?)?Z)?$')
+ISO_BASIC_RE = re.compile(r'(?P<year>\d{4})(?P<month>\d\d)(?P<day>\d\d)(T(?P<hour>\d\d)(?P<minute>\d\d)'
+                          r'((?P<second>\d\d)((?P<microsecond>\d{6}))?)?Z)?$')
+
+
+def parse_iso_datetime(value):
+    match = ISO_EXT_RE.match(value)
+    if not match:
+        match = ISO_BASIC_RE.match(value)
+    if not match:
+        raise ValueError("Invalid ISO timestamp {0!r}".format(value))
+    parts = dict((key, int(match.group(key) or '0'))
+                 for key in ('year', 'month', 'day', 'hour', 'minute', 'second', 'microsecond'))
+    return datetime.datetime(tzinfo=None, **parts)
+
+
+def get_iso_timestamp(fetch_time=None):
+    if not fetch_time:
+        fetch_time = datetime.datetime.utcnow()
+    elif fetch_time.tzinfo:
+        fetch_time = fetch_time.replace(tzinfo=None) - datetime.timedelta(seconds=fetch_time.utcoffset().seconds)
+    return fetch_time.isoformat() + "Z"

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -5,7 +5,11 @@ Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
 
-from pglookout.common import get_connection_info
+from pglookout.common import (
+    get_connection_info, convert_xlog_location_to_offset,
+    parse_iso_datetime, get_iso_timestamp, ISO_EXT_RE)
+from pytest import raises
+import datetime
 
 
 def test_connection_info():
@@ -23,3 +27,28 @@ def test_connection_info():
         }
     assert get_connection_info(ci) == get_connection_info(cs)
     assert get_connection_info(ci) == get_connection_info(url)
+
+
+def test_convert_xlog_location_to_offset():
+    assert convert_xlog_location_to_offset("1/00000000") == 1 << 32
+    assert convert_xlog_location_to_offset("F/AAAAAAAA") == (0xF << 32) | 0xAAAAAAAA
+    with raises(ValueError):
+        convert_xlog_location_to_offset("x")
+    with raises(ValueError):
+        convert_xlog_location_to_offset("x/y")
+
+
+def test_parse_iso_datetime():
+    date = datetime.datetime.utcnow()
+    date.replace(microsecond=0)
+    assert date == parse_iso_datetime(date.isoformat() + "Z")
+    with raises(ValueError):
+        parse_iso_datetime("foobar")
+
+
+def test_get_iso_timestamp():
+    v = get_iso_timestamp()
+    assert ISO_EXT_RE.match(v)
+    ts = datetime.datetime.now()
+    v = get_iso_timestamp(ts)
+    assert parse_iso_datetime(v) == ts

--- a/test/test_lookout.py
+++ b/test/test_lookout.py
@@ -8,8 +8,10 @@ This file is under the Apache License, Version 2.0.
 See the file `LICENSE` for details.
 """
 
-from pglookout.common import get_connection_info, get_connection_info_from_config_line
-from pglookout.pglookout import PgLookout, parse_iso_datetime, get_iso_timestamp
+from pglookout.common import (
+    get_connection_info, get_connection_info_from_config_line,
+    get_iso_timestamp)
+from pglookout.pglookout import PgLookout
 try:
     from mock import Mock  # pylint: disable=F0401
 except:  # py3k import location
@@ -59,11 +61,6 @@ class TestPgLookout(TestCase):
         self.pglookout.check_for_maintenance_mode_file.return_value = False
         self.temp_dir = tempfile.mkdtemp()
         self.state_file_path = os.path.join(self.temp_dir, "state_file")
-
-    def test_parse_iso_datetime(self):
-        date = datetime.datetime.utcnow()
-        date.replace(microsecond=0)
-        self.assertEqual(date, parse_iso_datetime(date.isoformat() + "Z"))
 
     def test_state_file_write(self):
         self.pglookout.config['json_state_file_path'] = self.state_file_path


### PR DESCRIPTION
    If we don't see a master node in the cluster before failover_timeout seconds
    have passed since the list of cluster nodes was last refreshed perform a
    failover to promote one of the standby nodes.  This is useful when a cluster
    has been brought up from backups and there is no existing master node.
    
    If a master node has been present in the cluster and later on disappears
    from both connections and configuration we should perform an immediate
    failover decision as there is no chance of reconnecting to a node that's no
    longer in our configuration.  This speeds up promotion when a node is
    deleted from the cluster.
