### PR TITLE
pglookout: Add a timeout for doing promotion if master removed from c…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,6 +253,12 @@ Time to sleep after a failover command has been issued.
 If a file exists in this location, this node will not be considered
 for promotion to master.
 
+``missing_master_from_config_timeout`` (default ``15``)
+
+In seconds the amount of time before we do a failover decision if a
+previously existing master has been removed from the config file and
+we have gotten a SIGHUP.
+
 ``alert_file_dir`` (default ``os.getcwd()``)
 
 Directory in which alert files for replication warning and failover

--- a/test/test_lookout.py
+++ b/test/test_lookout.py
@@ -239,6 +239,12 @@ class TestPgLookout(TestCase):
         # failover
         self.pglookout.current_master = "something obsolete"
         self.pglookout.check_cluster_state()
+        # No failover yet since we're  not over missing_master_from_config_timeout
+        assert self.pglookout.execute_external_command.call_count == 0
+
+        self.pglookout.cluster_nodes_change_time = time.time() - self.pglookout.missing_master_from_config_timeout
+        self.pglookout.current_master = "something obsolete"
+        self.pglookout.check_cluster_state()
         assert self.pglookout.execute_external_command.call_count == 1
 
     def test_failover_with_no_master_timeout(self):


### PR DESCRIPTION
…onfig

We also make it possible to trigger new cluster state checks immediately.
This allows us to get promptly refreshed state information every time
our configuration file is changed.