### PR TITLE
makefile: dnf --allowerasing for dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ rpm: $(generated)
 	$(RM) pglookout-rpm-src.tar
 
 build-dep-fed:
-	sudo yum -y install \
+	sudo dnf -y install --allowerasing \
 		python-devel python3-devel pytest python3-pytest pylint python3-pylint \
 		python-mock python3-mock python-psycopg2 python3-psycopg2 python-pytest-cov \
 		python-requests python3-requests rpm-build systemd-python systemd-python3 \


### PR DESCRIPTION
Allows replacing e.g. python-urllib3 with python2-urllib3